### PR TITLE
fix: use dynamic map dimensions in boundary check

### DIFF
--- a/includes/cub3d.h
+++ b/includes/cub3d.h
@@ -24,13 +24,12 @@
 #  include <X11/keysym.h>
 # endif
 
+/* Window Configuration */
 # define WINDOW_WIDTH 800
 # define WINDOW_HEIGHT 600
 # define TITLE "cub3D"
 
 /* Raycasting Constants */
-# define MAP_WIDTH 8
-# define MAP_HEIGHT 8
 # define FOV 60.0
 # define MOVE_SPEED 0.1
 # define ROT_SPEED 0.05

--- a/srcs/engine/player/player_slide.c
+++ b/srcs/engine/player/player_slide.c
@@ -74,7 +74,7 @@ static int	is_wall(t_game *game, double x, double y)
 	x2 = (int)(x + COLLISION_MARGIN);
 	y1 = (int)(y - COLLISION_MARGIN);
 	y2 = (int)(y + COLLISION_MARGIN);
-	if (x1 < 0 || x2 >= MAP_WIDTH || y1 < 0 || y2 >= MAP_HEIGHT)
+	if (x1 < 0 || x2 >= game->map_width || y1 < 0 || y2 >= game->map_height)
 		return (1);
 	if (game->world_map[y1][x1] != 0)
 		return (1);


### PR DESCRIPTION
- Changed player_slide.c to use game->map_width/map_height instead of hardcoded MAP_WIDTH/MAP_HEIGHT constants
- Removed unused MAP_WIDTH and MAP_HEIGHT defines from cub3d.h
- This ensures boundary checks work correctly for all map sizes, not just 8x8 maps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Map dimensions are now dynamic instead of fixed, allowing maps to support variable sizes at runtime.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->